### PR TITLE
Generating an elementary data ownership graph based on macro annotations

### DIFF
--- a/mongowner/mongowner-macros/Cargo.toml
+++ b/mongowner/mongowner-macros/Cargo.toml
@@ -10,6 +10,8 @@ quote = "1.0"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 mongodb = "2.7"
 proc-macro2 = "1.0"
+petgraph = { version = "0.6.4", features = ["serde-1"] }
+serde_json = "1.0.108"
 
 [lib]
 proc_macro = true

--- a/mongowner/mongowner-macros/Cargo.toml
+++ b/mongowner/mongowner-macros/Cargo.toml
@@ -10,8 +10,9 @@ quote = "1.0"
 syn = { version = "2.0", features = ["extra-traits", "full"] }
 mongodb = "2.7"
 proc-macro2 = "1.0"
-petgraph = { version = "0.6.4", features = ["serde-1"] }
+petgraph = { version = "0.6.4", features = ["serde-1", "graphmap"] }
 serde_json = "1.0.108"
+serde = "1.0.192"
 
 [lib]
 proc_macro = true

--- a/social-rs/server/Cargo.toml
+++ b/social-rs/server/Cargo.toml
@@ -14,3 +14,5 @@ actix-web = "4"
 dotenv = "0.15.0"
 uuid = "1.5.0"
 futures = "0.3.29"
+petgraph = { version = "0.6.4", features = ["serde-1", "graphmap"] }
+serde_json = "1.0.108"

--- a/social-rs/server/src/main.rs
+++ b/social-rs/server/src/main.rs
@@ -1,5 +1,6 @@
 mod post;
 mod user;
+use std::fs;
 use std::vec;
 use mongowner::Schemable;
 use user::User;
@@ -85,6 +86,15 @@ async fn add_user(client: web::Data<Client>, form: web::Json<User>) -> HttpRespo
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
+
+    // TODO: this should not be explicit code in this file
+    // create a file to store a serialized representation of a data ownership graph
+    let filepath = "graph.json";
+    match fs::write(&filepath, "") {
+        Ok(_) => println!("successfully created graph file"),
+        Err(_) => println!("could not create graph file"),
+    };
+
     // Replace the placeholder with your Atlas connection string
     let uri = std::env::var("MONGOURI").unwrap_or_else(|_| "mongodb://localhost:27017".into());
     let client = Client::with_uri_str(uri).await.expect("failed to connect");


### PR DESCRIPTION
**Requirements:** The `cargo.toml` files are updated with `serde`, `serde_json`, and `petgraph`. Also, you'll need an empty folder named `data` within `social-rs/server`; we can move to creating this directory ourselves or using a [temporary directory](https://docs.rs/tempdir/latest/tempdir/), but for now, this should work as a simple way to store our data ownership graph as a `graph.json` file. 

There are two main updates here:
- When we detect an edge (like User -> Post) based on our macro annotations, we now add this edge to the graph stored in the data/graph.json file (or create this file if it doesn't already exist). This works by deserializing the contents of the file to a `petgraph` graph, adding the edge, and serializing it back to the file.
- For now, we have explicit code in the server crate's `main.rs` file to load this graph and check that it has no cycles. This should probably be done via a separate one-line macro or hook in our final product, but it serves as a proof of concept for us being able to do this validation. Notably, this is validation that's happening at runtime, which is not what we want — we may need to find a way to do this at compile time after we build the graph. 

One implementation-related note is that we're using petgraph `GraphMap`s when building the graph because that lets us directly use strings as node references, instead of having to construct and worry about indexes. If we have two separate edges containing `User`, for example, it would be harder to use the regular `Graph` struct to identify that `User` already exists in the graph, and the default would be to create a new node with the same name.